### PR TITLE
Fix touch vertical-scroll hijack and broken RTL layout

### DIFF
--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import Carousel, { type ReactSimplyCarouselProps } from './index';
@@ -163,5 +163,92 @@ describe('ReactSimplyCarousel', () => {
     );
     const btn = screen.getByRole('button', { name: 'go-next' });
     expect(btn).toHaveClass('fwd-btn');
+  });
+
+  describe('touch swipe axis lock', () => {
+    const getItemsList = () =>
+      document.querySelector('[role="presentation"]') as HTMLElement;
+
+    it('requests a slide change on a horizontal swipe', () => {
+      const onRequestChange = jest.fn();
+      render(<Harness onRequestChange={onRequestChange} />);
+      const list = getItemsList();
+
+      fireEvent.touchStart(list, { touches: [{ clientX: 200, clientY: 100 }] });
+      fireEvent.touchMove(document, {
+        touches: [{ clientX: 100, clientY: 105 }],
+      });
+      fireEvent.touchEnd(document, {
+        changedTouches: [{ clientX: 100, clientY: 105 }],
+      });
+
+      expect(onRequestChange).toHaveBeenCalled();
+    });
+
+    it('ignores a mostly-vertical move so the page can scroll', () => {
+      const onRequestChange = jest.fn();
+      render(<Harness onRequestChange={onRequestChange} />);
+      const list = getItemsList();
+
+      fireEvent.touchStart(list, { touches: [{ clientX: 100, clientY: 200 }] });
+      fireEvent.touchMove(document, {
+        touches: [{ clientX: 108, clientY: 100 }],
+      });
+      fireEvent.touchEnd(document, {
+        changedTouches: [{ clientX: 108, clientY: 100 }],
+      });
+
+      expect(onRequestChange).not.toHaveBeenCalled();
+    });
+
+    it('keeps the gesture locked to vertical even if it later drifts horizontally', () => {
+      const onRequestChange = jest.fn();
+      render(<Harness onRequestChange={onRequestChange} />);
+      const list = getItemsList();
+
+      fireEvent.touchStart(list, { touches: [{ clientX: 100, clientY: 200 }] });
+      // First move is vertical-dominant → locks to 'y'.
+      fireEvent.touchMove(document, {
+        touches: [{ clientX: 104, clientY: 100 }],
+      });
+      // Later horizontal drift must stay ignored.
+      fireEvent.touchMove(document, {
+        touches: [{ clientX: 250, clientY: 90 }],
+      });
+      fireEvent.touchEnd(document, {
+        changedTouches: [{ clientX: 250, clientY: 90 }],
+      });
+
+      expect(onRequestChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('dirRTL (right-to-left)', () => {
+    const getInner = () =>
+      document.querySelector('[role="presentation"]')!.parentElement as HTMLElement;
+
+    it('lays the viewport out right-to-left so slides are not pushed off-screen', () => {
+      render(<Harness dirRTL />);
+      // Without direction:rtl the positive translateX shifts the list out of
+      // the viewport (issues #248/#250). The inner viewport must be rtl so the
+      // list is right-anchored and the slides stay visible.
+      expect(getInner().style.direction).toBe('rtl');
+    });
+
+    it('does not force rtl direction in LTR mode', () => {
+      render(<Harness />);
+      expect(getInner().style.direction).toBe('');
+    });
+
+    it('forward navigation still requests the next slide index in RTL', async () => {
+      const user = userEvent.setup();
+      const onRequestChange = jest.fn();
+      render(<Harness dirRTL onRequestChange={onRequestChange} />);
+
+      await user.click(screen.getByRole('button', { name: 'Next' }));
+
+      expect(onRequestChange).toHaveBeenCalledTimes(1);
+      expect(onRequestChange.mock.calls[0][0]).toBe(1);
+    });
   });
 });

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -101,6 +101,8 @@ function ReactSimplyCarousel({
   const isMissingTransitionEndRef = useRef(false);
 
   const itemsListDragStartPosRef = useRef(0);
+  const itemsListDragStartPosYRef = useRef(0);
+  const swipeAxisRef = useRef<'' | 'x' | 'y'>('');
   const isListDraggingRef = useRef(false);
 
   const directionRef = useRef<NavDirection | ''>('');
@@ -686,6 +688,28 @@ function ReactSimplyCarousel({
 
       const dxRaw = itemsListDragStartPosRef.current - dragPos;
 
+      // On touch, lock the gesture to its dominant axis once it passes the
+      // slop. A mostly-vertical move locks to 'y' so the carousel ignores it
+      // and the page can scroll normally instead of being hijacked by a
+      // slight horizontal jitter.
+      if (isTouch && swipeAxisRef.current === '') {
+        const dragPosY = (event as TouchEvent).touches?.[0].clientY;
+        const dyRaw = itemsListDragStartPosYRef.current - dragPosY;
+
+        if (
+          Math.abs(dxRaw) <= DRAG_SLOP_PX &&
+          Math.abs(dyRaw) <= DRAG_SLOP_PX
+        ) {
+          return;
+        }
+
+        swipeAxisRef.current = Math.abs(dxRaw) > Math.abs(dyRaw) ? 'x' : 'y';
+      }
+
+      if (swipeAxisRef.current === 'y') {
+        return;
+      }
+
       if (!isListDraggingRef.current && Math.abs(dxRaw) <= DRAG_SLOP_PX) {
         return;
       }
@@ -764,6 +788,8 @@ function ReactSimplyCarousel({
         );
       }
       itemsListDragStartPosRef.current = 0;
+      itemsListDragStartPosYRef.current = 0;
+      swipeAxisRef.current = '';
       isListDraggingRef.current = false;
     }
 
@@ -773,10 +799,14 @@ function ReactSimplyCarousel({
       const isTouch = !!(event as TouchEvent).touches?.[0];
 
       isListDraggingRef.current = false;
+      swipeAxisRef.current = '';
 
       itemsListDragStartPosRef.current = isTouch
         ? (event as TouchEvent).touches?.[0].clientX
         : (event as MouseEvent).clientX;
+      itemsListDragStartPosYRef.current = isTouch
+        ? (event as TouchEvent).touches?.[0].clientY
+        : (event as MouseEvent).clientY;
 
       if (isTouch) {
         document.addEventListener('touchmove', handleListSwipe as () => {});
@@ -813,6 +843,8 @@ function ReactSimplyCarousel({
     return () => {
       isListDraggingRef.current = false;
       itemsListDragStartPosRef.current = 0;
+      itemsListDragStartPosYRef.current = 0;
+      swipeAxisRef.current = '';
       listRef?.removeEventListener('click', preventClick, preventClickOptions);
 
       listRef?.removeEventListener(
@@ -973,6 +1005,7 @@ function ReactSimplyCarousel({
         style={{
           width: '100%',
           ...innerStyle,
+          direction: dirRTL ? 'rtl' : undefined,
           display: 'flex',
           boxSizing: 'border-box',
           flexFlow: 'row wrap',


### PR DESCRIPTION
## Summary

Two related touch/layout fixes, verified in a browser against the library source.

### 1. Touch swipe hijacks vertical page scroll (#232)
The swipe handler only tracked the X axis, so a mostly-vertical scroll over the carousel with slight horizontal jitter started a horizontal swipe. The only mitigation, `preventScrollOnSwipe` (`touchAction: none`), disabled vertical scrolling entirely — trapping the user.

Now the gesture **locks to its dominant axis** on the first move past the slop: a mostly-vertical move locks to `y` and is ignored (page scrolls normally), a horizontal move drives the carousel as before. Mouse behaviour is unchanged.

### 2. `dirRTL` renders an empty / stuck carousel (#248, #250)
`dirRTL` only flipped the `translateX` sign (to positive), but nothing laid the flex list out right-to-left, so the list was never right-anchored and got pushed off-screen. Result: empty viewport, wrong starting slide (#250), and swipe/nav appearing "blocked" (#248).

Fix: set `direction: rtl` on the inner viewport container when `dirRTL` is on. This right-anchors the list (so the positive `translateX` math reveals slides correctly) and cascades the right-to-left order + text direction the prop documents.

## Verification
Reproduced and verified visually in a Vite demo via Chrome DevTools:
- RTL now starts on slide 0 (anchored right); forward cycles `1→2→3→4→5→0→1`, backward wraps correctly.
- Touch swipe left/right moves in both directions with a clean settled transform — no sticking.
- LTR is unaffected.

## Tests
Added `touch swipe axis lock` and `dirRTL` test suites. **17/17 pass**, lint and type-check clean.

Closes #232
Closes #248
Closes #250